### PR TITLE
chore: some Dockerfile improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Standard docker ignore for nodejs
+.git
+.github
+.gitignore
+node_modules
+env


### PR DESCRIPTION
## Description

Dockerfile has been modified with the following:
- remove absolute dir when copy files around relying on the WORKDIR
- bundled together subsequent run statements
- dropped root privileges
- running tini as ENTRYPOINT to get rid of signal errors when closing the container

This PR does not solve any issue but is to make the Dockerfile more "production-like" optimising build statements and dropping root privileges.

If anyone is curious, I have tried to change the base image to the `slim-buster` variant but the `alpine` version is significantly smaller for node, so I guess if we want to save some space the current image is better.
